### PR TITLE
Jsonized taxonomy results

### DIFF
--- a/americangut/taxtree.py
+++ b/americangut/taxtree.py
@@ -161,6 +161,9 @@ def build_persample_tree_from_taxontable(table):
     abundance.
     """
     samp_ids = table.ids()
+
+    # It is assumed the IDs are of the form "foo; bar" or "foo;bar". Both of
+    # which have been produced by QIIME's summarize_taxa.py
     obs_ids_tmp = table.ids(axis='observation')
     obs_ids = [[t.strip() for t in i.split(';')] for i in obs_ids_tmp]
 

--- a/americangut/taxtree.py
+++ b/americangut/taxtree.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from biom.parse import parse_biom_table
+from itertools import izip
+
 
 __author__ = "Daniel McDonald"
 __copyright__ = "Copyright 2013, The American Gut Project"
@@ -11,9 +12,11 @@ __maintainer__ = "Daniel McDonald"
 __email__ = "mcdonadt@colorado.edu"
 
 
-def create_node(name):
+def create_node(name, **kwargs):
     """Create and return a new node"""
-    return {'name': name, 'popcount': 0, 'children': []}
+    n = {'name': name, 'children': []}
+    n.update(kwargs)
+    return n
 
 
 def add_node(cur_node, node):
@@ -38,7 +41,7 @@ def update_tree(tree, taxa_by_sample):
         children : list of nodes
     """
     if tree is None:
-        tree = create_node('root')
+        tree = create_node('root', popcount=0)
 
     for list_of_taxa in taxa_by_sample:
         tree['popcount'] += 1
@@ -53,7 +56,7 @@ def update_tree(tree, taxa_by_sample):
                 node = get_node(cur_node, taxon)
 
                 if node is None:
-                    node = create_node(taxon)
+                    node = create_node(taxon, popcount=0)
                     add_node(cur_node, node)
 
                 if taxon not in seen:
@@ -61,6 +64,33 @@ def update_tree(tree, taxa_by_sample):
                     seen.add(taxon)
 
                 cur_node = node
+    return tree
+
+
+def set_relative_freqs(tree):
+    """Set freqs on tree"""
+    total_count = float(tree['count'])
+    tree['freq'] = tree['count'] / total_count
+
+    for node in traverse(tree):
+        node['freq'] = node['count'] / total_count
+
+
+def update_per_sample_tree(tree, taxons, count):
+    """Updates a per-sample tree"""
+    if tree is None:
+        tree = create_node('root', count=0, freq=None)
+
+    tree['count'] += count
+    cur_node = tree
+    for taxon in taxons:
+        node = get_node(cur_node, taxon)
+
+        if node is None:
+            node = create_node(taxon, count=0, freq=None)
+            add_node(cur_node, node)
+        node['count'] += count
+        cur_node = node
     return tree
 
 
@@ -115,12 +145,34 @@ def build_tree_from_taxontable(table):
         sample_taxa = []
         for taxon, freq in zip(table.ids(axis='observation'), taxa_freqs):
             if freq > 0:
-                sample_taxa.append(taxon.split('; '))
+                sample_taxa.append([t.strip() for t in taxon.split(';')])
         sample_taxa_lookup[sample_id] = sample_taxa
 
     tree = update_tree(None, sample_taxa_lookup.values())
 
     return tree, sample_taxa_lookup
+
+
+def build_persample_tree_from_taxontable(table):
+    """Construct per-sample trees from a taxon table
+
+    yields (sample_id, tree). Each node in the tree (tip and nontip) include
+    the taxon name, associated sequence count as well as the relative
+    abundance.
+    """
+    samp_ids = table.ids()
+    obs_ids_tmp = table.ids(axis='observation')
+    obs_ids = [[t.strip() for t in i.split(';')] for i in obs_ids_tmp]
+
+    for samp_id in samp_ids:
+        tree = create_node('root', count=0, freq=None)
+        data = table.data(samp_id)
+        for obs_id, count in izip(obs_ids, data):
+            if count == 0:
+                continue
+            update_per_sample_tree(tree, obs_id, count)
+        set_relative_freqs(tree)
+        yield (samp_id, tree)
 
 
 def sample_rare_unique(tree, table, all_sample_taxa, rare_threshold):
@@ -146,17 +198,6 @@ def sample_rare_unique(tree, table, all_sample_taxa, rare_threshold):
         if table is None:
             yield (sample_id, None, rare, unique)
         else:
-            filtered = table.filter(filter_f, axis='observation', inplace=False)
+            filtered = table.filter(filter_f, axis='observation',
+                                    inplace=False)
             yield (sample_id, filtered, rare, unique)
-
-
-if __name__ == '__main__':
-    from sys import argv
-    table = parse_biom_table(open(argv[1]))
-    tree, all_taxa = build_tree_from_taxontable(table)
-    print "#SampleID\ttype\ttaxon"
-    for samp, ft, rare, uniq in sample_rare_unique(tree, None, all_taxa, 0.01):
-        for r in rare:
-            print "%s\t%s\t%s" % (samp, 'rare', r)
-        for u in uniq:
-            print "%s\t%s\t%s" % (samp, 'unique', u)

--- a/scripts/ag
+++ b/scripts/ag
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-import click
 import os
 import json
 from gzip import open as gzopen
 
+import click
 from biom import load_table
 
 from americangut.taxtree import (build_tree_from_taxontable,
@@ -23,7 +23,8 @@ def taxtree():
 
 
 @taxtree.command()
-@click.option('--table', required=True, type=click.Path(exists=True),
+@click.option('--table', required=True, type=click.Path(exists=True,
+                                                        dir_okay=False),
               help='The input BIOM taxon table')
 @click.option('--rare-threshold', required=False,
               default=0.01, help='The threshold to consider an OTU rare')
@@ -40,11 +41,13 @@ def rareunique(table, rare_threshold):
 
 
 @taxtree.command()
-@click.option('--table', required=True, type=click.Path(exists=True),
+@click.option('--table', required=True, type=click.Path(exists=True,
+                                                        dir_okay=False),
               help='The input BIOM taxon table')
-@click.option('--output', required=True, type=click.Path(exists=False))
+@click.option('--output', required=True, type=click.Path(exists=False,
+                                                         writable=True))
 def persample_json(table, output):
-    os.makedirs(output)
+    os.makedirs(os.path.abspath(output))
     table = load_table(table)
     for samp, tree in build_persample_tree_from_taxontable(table):
         with gzopen(os.path.join(output, '%s.json.gz' % samp), 'w') as fp:

--- a/scripts/ag
+++ b/scripts/ag
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import click
+import os
+import json
+from gzip import open as gzopen
+
+from biom import load_table
+
+from americangut.taxtree import (build_tree_from_taxontable,
+                                 sample_rare_unique,
+                                 build_persample_tree_from_taxontable)
+
+
+@click.group()
+def ag():
+    pass
+
+
+@ag.group()
+def taxtree():
+    pass
+
+
+@taxtree.command()
+@click.option('--table', required=True, type=click.Path(exists=True),
+              help='The input BIOM taxon table')
+@click.option('--rare-threshold', required=False,
+              default=0.01, help='The threshold to consider an OTU rare')
+def rareunique(table, rare_threshold):
+    table = load_table(table)
+    tree, all_taxa = build_tree_from_taxontable(table)
+    click.echo("#SampleID\ttype\ttaxon")
+    it = sample_rare_unique(tree, None, all_taxa, rare_threshold)
+    for samp, ft, rare, uniq in it:
+        for r in rare:
+            click.echo("%s\t%s\t%s" % (samp, 'rare', r))
+        for u in uniq:
+            click.echo("%s\t%s\t%s" % (samp, 'unique', u))
+
+
+@taxtree.command()
+@click.option('--table', required=True, type=click.Path(exists=True),
+              help='The input BIOM taxon table')
+@click.option('--output', required=True, type=click.Path(exists=False))
+def persample_json(table, output):
+    os.makedirs(output)
+    table = load_table(table)
+    for samp, tree in build_persample_tree_from_taxontable(table):
+        with gzopen(os.path.join(output, '%s.json.gz' % samp), 'w') as fp:
+            fp.write(json.dumps(tree, indent=2))
+
+
+if __name__ == '__main__':
+    ag()

--- a/tests/test_taxtree.py
+++ b/tests/test_taxtree.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
 from unittest import TestCase, main
-from americangut.taxtree import create_node, add_node, get_node, update_tree, \
-        get_rare_unique, traverse, sample_rare_unique
-from biom.table import table_factory
+
 from numpy import array
 from copy import deepcopy
+from biom import Table
+
+from americangut.taxtree import create_node, add_node, get_node, update_tree, \
+        get_rare_unique, traverse, sample_rare_unique, \
+        build_persample_tree_from_taxontable, set_relative_freqs, \
+        update_per_sample_tree
 
 __author__ = "Daniel McDonald"
 __copyright__ = "Copyright 2013, The American Gut Project"
@@ -16,38 +20,124 @@ __maintainer__ = "Daniel McDonald"
 __email__ = "mcdonadt@colorado.edu"
 
 class TaxTreeTests(TestCase):
+    def setUp(self):
+        ta = {'name': 'root',
+              'count': 36,
+              'freq': 1.0,
+              'children': [{'name': 'k__1',
+                            'count': 36,
+                            'freq': 1.0,
+                            'children': [{'name': 'p__x',
+                                          'count': 12,
+                                          'freq': 12.0 / 36.0,
+                                          'children': [{'name': 'c__1',
+                                                        'count': 1,
+                                                        'freq': 1.0 / 36,
+                                                        'children': []},
+                                                       {'name': 'c__2',
+                                                        'count': 4,
+                                                        'freq': 4.0 / 36,
+                                                        'children': []},
+                                                       {'name': 'c__',
+                                                        'count': 7,
+                                                        'freq': 7.0 / 36,
+                                                        'children': []}]},
+                                         {'name': 'p__y',
+                                          'count': 24,
+                                          'freq': 24.0 / 36.0,
+                                          'children': [{'name': 'c__3',
+                                                        'count': 10,
+                                                        'freq': 10.0 / 36.0,
+                                                        'children': []},
+                                                       {'name': 'c__',
+                                                        'count': 14,
+                                                        'freq': 14.0 / 36.0,
+                                                        'children': []}]}]}]}
+        self.persample = ta
+
+    def test_build_persample_tree_from_taxontable(self):
+        exp_a = ('a', self.persample)
+        obs_a = build_persample_tree_from_taxontable(table).next()
+        self.assertEqual(obs_a, exp_a)
+
+    def test_set_relative_freqs(self):
+        persample_copy = deepcopy(self.persample)
+        self.persample['freq'] = None
+        for node in traverse(self.persample):
+            node['freq'] = None
+        set_relative_freqs(self.persample)
+        self.assertEqual(persample_copy, self.persample)
+
+    def test_update_per_sample_tree(self):
+        taxons = (('k__a', 'p__x'),
+                  ('k__a', 'p__x'),
+                  ('k__a', 'p__y'),  # indep of p__x; c__1
+                  ('k__b', 'p__z'))
+        counts = (5, 7, 9, 11)
+        exp = {'name': 'root',
+               'count': 32,
+               'freq': None,
+               'children': [{'name': 'k__a',
+                             'count': 21,
+                             'freq': None,
+                             'children': [{'name': 'p__x',
+                                           'count': 12,
+                                           'freq': None,
+                                           'children': []},
+                                          {'name': 'p__y',
+                                           'count': 9,
+                                           'freq': None,
+                                           'children': []}]},
+                            {'name': 'k__b',
+                             'count': 11,
+                             'freq': None,
+                             'children': [{'name': 'p__z',
+                                           'count': 11,
+                                           'freq': None,
+                                           'children': []}]}]}
+
+        tree = create_node('root', count=0, freq=None)
+        update_per_sample_tree(tree, taxons[0], counts[0])
+        update_per_sample_tree(tree, taxons[1], counts[1])
+        update_per_sample_tree(tree, taxons[2], counts[2])
+        update_per_sample_tree(tree, taxons[3], counts[3])
+        self.assertEqual(tree, exp)
+
     def test_sample_rare_unique(self):
         t = update_tree(None, tax_strings_by_sample)
         tax_by_sample = {'a':tax_strings_by_sample[0],
                          'b':tax_strings_by_sample[1],
                          'c':tax_strings_by_sample[2]}
-        exp = [('a', None, [['k__1','p__x','c__'],['k__1','p__y','c__3']], 
+        exp = [('a', None, [['k__1','p__x','c__'],['k__1','p__y','c__3']],
                            [['k__1','p__x','c__1'],['k__1','p__x','c__2']]),
                ('b', None, [['k__1','p__x','c__'],['k__1','p__y','c__3']], []),
                ('c', None, [], [])]
         obs = sample_rare_unique(t, None, tax_by_sample, 0.7)
         self.assertEqual(sorted(obs), exp)
 
-        table_a = table_factory(array([[14,15,16]]), ['a','b','c'], 
-                                ['k__1; p__y; c__'])
-        table_b = table_factory(array([[1,2,3],
-                                       [4,5,6],
-                                       [14,15,16]]), ['a','b','c'], 
-                                    ['k__1; p__x; c__1',
-                                     'k__1; p__x; c__2',
-                                     'k__1; p__y; c__'])
-        table_c = table_factory(array([[1,2,3],
-                                       [4,5,6],
-                                       [7,8,9],
-                                       [10,11,12],
-                                       [14,15,16]]), ['a','b','c'], 
-                                    ['k__1; p__x; c__1',
-                                     'k__1; p__x; c__2',
-                                     'k__1; p__x; c__',
-                                     'k__1; p__y; c__3',
-                                     'k__1; p__y; c__'])
+        table_a = Table(array([[14,15,16]]),
+                               ['k__1; p__y; c__'],
+                               ['a','b','c'])
+        table_b = Table(array([[1,2,3],
+                               [4,5,6],
+                               [14,15,16]]),
+                        ['k__1; p__x; c__1',
+                         'k__1; p__x; c__2',
+                         'k__1; p__y; c__'],
+                        ['a','b','c'], )
+        table_c = Table(array([[1,2,3],
+                               [4,5,6],
+                               [7,8,9],
+                               [10,11,12],
+                               [14,15,16]]),
+                        ['k__1; p__x; c__1',
+                         'k__1; p__x; c__2',
+                         'k__1; p__x; c__',
+                         'k__1; p__y; c__3',
+                         'k__1; p__y; c__'],
+                        ['a','b','c'])
 
-        exp = [('a', table_a, [['k__1','p__x','c__'],['k__1','p__y','c__3']], 
+        exp = [('a', table_a, [['k__1','p__x','c__'],['k__1','p__y','c__3']],
                            [['k__1','p__x','c__1'],['k__1','p__x','c__2']]),
                ('b', table_b, [['k__1','p__x','c__'],['k__1','p__y','c__3']], []),
                ('c', table_c, [], [])]
@@ -60,7 +150,7 @@ class TaxTreeTests(TestCase):
             self.assertEqual(o[3], e[3])
 
     def test_create_node(self):
-        exp = {'name':'foo','popcount':0,'children':[]}
+        exp = {'name':'foo','children':[]}
         obs = create_node('foo')
         self.assertEqual(obs, exp)
 
@@ -71,12 +161,12 @@ class TaxTreeTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_add_node(self):
-        exp = {'name':'foo','popcount':0,'children':[
-                        {'name':'bar', 'popcount':0, 'children':[]}
+        exp = {'name':'foo','popcount':1,'children':[
+                        {'name':'bar', 'popcount':2, 'children':[]}
                      ]
               }
-        foo = create_node('foo')
-        bar = create_node('bar')
+        foo = create_node('foo', popcount=1)
+        bar = create_node('bar', popcount=2)
         add_node(foo,bar)
         self.assertEqual(foo, exp)
 
@@ -86,23 +176,23 @@ class TaxTreeTests(TestCase):
                     ]}
         self.assertEqual(get_node(tree, 'does not exist'), None)
         self.assertEqual(get_node(tree, 'bar'), tree['children'][0])
-    
+
     def test_create_tree(self):
         """take tax strings, create a tree"""
         exp = {'name':'root',
-                'popcount':3, 
+                'popcount':3,
                 'children':[
                     {'name':'k__1',
                      'popcount':3,
                      'children':[
-                        {'name':'p__x', 
+                        {'name':'p__x',
                          'popcount':2,
                          'children':[
-                            {'name':'c__1', 
-                             'popcount':1, 
+                            {'name':'c__1',
+                             'popcount':1,
                              'children':[]},
-                            {'name':'c__2', 
-                             'popcount':1, 
+                            {'name':'c__2',
+                             'popcount':1,
                              'children':[]}
                             ]
                         },
@@ -124,19 +214,19 @@ class TaxTreeTests(TestCase):
     def test_create_tree_ignore_contested(self):
         """take tax strings, create a tree"""
         exp = {'name':'root',
-                'popcount':3, 
+                'popcount':3,
                 'children':[
                     {'name':'k__1',
                      'popcount':3,
                      'children':[
-                        {'name':'p__x', 
+                        {'name':'p__x',
                          'popcount':2,
                          'children':[
-                            {'name':'c__1', 
-                             'popcount':1, 
+                            {'name':'c__1',
+                             'popcount':1,
                              'children':[]},
-                            {'name':'c__2', 
-                             'popcount':1, 
+                            {'name':'c__2',
+                             'popcount':1,
                              'children':[]}
                             ]
                         },
@@ -157,7 +247,7 @@ class TaxTreeTests(TestCase):
         exp_unique = [['k__1','p__x','c__2']]
         exp_rare = [['k__1','p__x','c__'],['k__1','p__y','c__3']]
         obs_rare, obs_unique = get_rare_unique(t, sample_taxa, 0.7)
-        
+
         self.assertEqual(obs_rare, exp_rare)
         self.assertEqual(obs_unique, exp_unique)
 
@@ -184,20 +274,24 @@ tax_strings_by_sample = [
         ]
     ]
 
-table = table_factory(array([[1,2,3],
-           [4,5,6],
-           [7,8,9],
-           [10,11,12],
-           [14,15,16]]), ['a','b','c'],['k__1; p__x; c__1', 
-                                        'k__1; p__x; c__2', 
-                                        'k__1; p__x; c__',
-                                        'k__1; p__y; c__3',
-                                        'k__1; p__y; c__'])
+table = Table(array([[1,2,3],
+                     [4,5,6],
+                     [7,8,9],
+                     [10,11,12],
+                     [14,15,16]]),
+              ['k__1; p__x; c__1',
+               'k__1; p__x; c__2',
+               'k__1; p__x; c__',
+               'k__1; p__y; c__3',
+               'k__1; p__y; c__'],
+              ['a','b','c'])
 
 sample_taxa = [
         ['k__1','p__x','c__2'],
         ['k__1','p__x','c__'],
         ['k__1','p__y','c__3']
     ]
+
+
 if __name__ == '__main__':
     main()

--- a/tests/test_taxtree.py
+++ b/tests/test_taxtree.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 from unittest import TestCase, main
+from copy import deepcopy
 
 from numpy import array
-from copy import deepcopy
 from biom import Table
 
 from americangut.taxtree import create_node, add_node, get_node, update_tree, \


### PR DESCRIPTION
This produces JSON-based taxonomy summaries using nested objects. Each taxon is represented, as well as its count and relative frequency. The intent here is to provide a reasonably easily consumable format for web applications for representing per-sample taxonomy results. Newick is not ideal here as you have to hack it in order to embed metadata. JSON is not _great_ for trees due to the nesting, however taxonomy in bacteria and archaea top out at 7 levels (8 including root) and eukarya top out at I believe 14 (15 with root), so the nesting is not extreme.

Note, this is _not_ using scikit-bio's `TreeNode`. The taxtree code was put in place prior to scikit-bio, and we needed code that was BSD (hence not using cogent). It was easier to just adapt the existing code here than to do a larger refactoring. 

@madprime, just to keep you in the loop as it may be cool to provide these in the Open Humans pulldown. What I think we'll end up doing is hosting these via www.microbio.me as public downloads but I haven't resolved that specifically. What this then lets us do is provide relative abundance tab-delimited taxonomy tables and well as a computable format for the full taxonomy easily. 