### PR TITLE
Adding unspecified to the list of unspecified body site

### DIFF
--- a/americangut/util.py
+++ b/americangut/util.py
@@ -498,7 +498,8 @@ def clean_and_reformat_mapping(in_fp, out_fp, body_site_column_name,
             body_site = body_site.split('_', 1)[-1].replace("_", " ")
         elif body_site.startswith('UBERON:'):
             body_site = body_site.split(':', 1)[-1]
-        elif body_site in ['NA', 'unknown', '', 'no_data', 'None', 'Unknown']:
+        elif body_site in ['NA', 'unknown', '', 'no_data', 'None', 'Unknown',
+                           'Unspecified']:
             errors[('unspecified_bodysite', body_site)].append(sample_id)
             continue
         else:


### PR DESCRIPTION
Qiita no longer changes Unspecified to Unknown, so this value needs to be added to the list of 'unspecified' body sites, so the primary processing can go smoothly.